### PR TITLE
Exclude test data artifacts from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ _site
 
 # This is an extracted file from spec/fixtures
 spec/fixtures/MUANGL20/MAUNINST.EXE
+
+# Test data source files (match filenames in libmspack CAB test archives)
+/hello.c
+/welcome.c


### PR DESCRIPTION
## Summary

Exclude test data artifacts that appear in the project root from git tracking.

## Context

- `hello.c` and `welcome.c` are 1997-era C source files matching filenames inside libmspack CAB test archives
- They are test data, not project source code
- `spec/fixtures/MUANGL20/MAUNINST.EXE` was already excluded but the source files were not
