### PR TITLE
Replace spec instance variable access with idle predicate

### DIFF
--- a/TODO.fixup/21-extractor-state-object.md
+++ b/TODO.fixup/21-extractor-state-object.md
@@ -1,0 +1,40 @@
+# TODO 21: Extract CAB extractor extraction state into a state object
+
+## Priority: P2 (duplication, silent-drift risk)
+
+## Problem
+`CAB::Extractor` keeps its per-folder extraction state in four instance
+variables: `@current_input`, `@current_decomp`, `@current_folder` and
+`@current_offset`. Two methods in `lib/cabriolet/cab/extractor.rb` each
+hand-list all four:
+
+- `reset_state` clears them
+- `idle?` reports whether they are all clear
+
+Nothing keeps the two lists in step. Add a fifth piece of extraction state and
+clear it in `reset_state` without adding it to `idle?`, and every
+`expect(extractor).to be_idle` assertion silently stops guarding that field
+while the suite stays green. A pointer comment on each method is the current
+mitigation; it depends on the next editor reading it.
+
+Surfaced by the Gate A review of TODO 06, which replaced the specs'
+`instance_variable_get` pokes with `idle?`.
+
+## Solution
+Extract the four fields into a small state object (for example
+`CAB::Extractor::FolderState`) owning the enumeration once:
+
+1. The object holds input, decompressor, folder and offset.
+2. `#release` closes the input, frees the decompressor and clears the fields.
+3. `#idle?` derives from the same enumeration rather than repeating it.
+4. `Extractor#reset_state` and `Extractor#idle?` delegate to it.
+
+This touches every extraction-state read in `extractor.rb`, including
+`setup_decompressor_for_folder`, `skip_to_file_offset` and `write_file_data`,
+so it belongs in its own change rather than riding along with a spec cleanup.
+
+## Verification
+- `reset_state` and `idle?` no longer enumerate the fields independently
+- Mutation check: removing any single field's clearing from the state object
+  turns at least one `be_idle` example red
+- `spec/cab/extractor_spec.rb` and `spec/cab/memory_spec.rb` pass unchanged

--- a/TODO.fixup/22-extractor-state-object.md
+++ b/TODO.fixup/22-extractor-state-object.md
@@ -1,4 +1,4 @@
-# TODO 21: Extract CAB extractor extraction state into a state object
+# TODO 22: Extract CAB extractor extraction state into a state object
 
 ## Priority: P2 (duplication, silent-drift risk)
 

--- a/lib/cabriolet/cab/extractor.rb
+++ b/lib/cabriolet/cab/extractor.rb
@@ -68,7 +68,11 @@ module Cabriolet
         filelen
       end
 
-      # Reset extraction state (used in salvage mode to recover from errors)
+      # Reset extraction state
+      #
+      # Called unconditionally after every extract_all, and in salvage mode to
+      # recover from errors. Any field cleared here must also be checked by
+      # #idle?, which reports the same state.
       def reset_state
         @current_input&.close
         @current_input = nil
@@ -76,6 +80,17 @@ module Cabriolet
         @current_decomp = nil
         @current_folder = nil
         @current_offset = 0
+      end
+
+      # Whether the extractor has no folder currently open for extraction
+      #
+      # Mirrors the fields #reset_state clears; keep the two in step.
+      #
+      # @return [Boolean] true when no input, decompressor, folder or stream
+      #   offset is held
+      def idle?
+        @current_input.nil? && @current_decomp.nil? && @current_folder.nil? &&
+          @current_offset.zero?
       end
 
       # Extract all files from a cabinet

--- a/spec/cab/extractor_spec.rb
+++ b/spec/cab/extractor_spec.rb
@@ -113,6 +113,35 @@ RSpec.describe Cabriolet::CAB::Extractor do
     end
   end
 
+  describe "#idle?" do
+    it "is true for a newly created extractor" do
+      expect(extractor).to be_idle
+    end
+
+    it "is false while a folder is still open" do
+      cabinet = decompressor.open(normal_2files_1folder)
+
+      Dir.mktmpdir do |tmpdir|
+        extractor.extract_file(cabinet.files.first,
+                               File.join(tmpdir, "out.txt"))
+      end
+
+      expect(extractor).not_to be_idle
+    end
+
+    it "is true again after reset_state" do
+      cabinet = decompressor.open(normal_2files_1folder)
+
+      Dir.mktmpdir do |tmpdir|
+        extractor.extract_file(cabinet.files.first,
+                               File.join(tmpdir, "out.txt"))
+      end
+      extractor.reset_state
+
+      expect(extractor).to be_idle
+    end
+  end
+
   describe "#extract_all" do
     context "with default options" do
       it "extracts all files preserving paths" do

--- a/spec/cab/extractor_spec.rb
+++ b/spec/cab/extractor_spec.rb
@@ -114,6 +114,10 @@ RSpec.describe Cabriolet::CAB::Extractor do
   end
 
   describe "#idle?" do
+    # The middle example deliberately leaves a folder open, so release the
+    # handle here rather than waiting on GC.
+    after { extractor.reset_state }
+
     it "is true for a newly created extractor" do
       expect(extractor).to be_idle
     end

--- a/spec/cab/memory_spec.rb
+++ b/spec/cab/memory_spec.rb
@@ -81,9 +81,44 @@ RSpec.describe "Cabriolet Memory Management" do
         end
 
         # reset_state is called automatically in ensure block
-        expect(extractor.instance_variable_get(:@current_input)).to be_nil
-        expect(extractor.instance_variable_get(:@current_decomp)).to be_nil
-        expect(extractor.instance_variable_get(:@current_folder)).to be_nil
+        expect(extractor).to be_idle
+      end
+
+      it "frees the decompressor it releases" do
+        cabinet = decompressor.open(cab_file)
+        extractor = Cabriolet::CAB::Extractor.new(decompressor.io_system,
+                                                  decompressor)
+        created = nil
+        allow(decompressor).to(
+          receive(:create_decompressor).and_wrap_original do |original, *args|
+            created = original.call(*args)
+          end,
+        )
+
+        Dir.mktmpdir do |tmpdir|
+          extractor.extract_file(cabinet.files.first,
+                                 File.join(tmpdir, "out.txt"))
+        end
+
+        expect(created).not_to be_nil
+        expect(created).to receive(:free)
+
+        extractor.reset_state
+      end
+
+      it "clears internal state when the progress callback raises" do
+        cabinet = decompressor.open(cab_file)
+        extractor = Cabriolet::CAB::Extractor.new(decompressor.io_system,
+                                                  decompressor)
+
+        expect do
+          Dir.mktmpdir do |tmpdir|
+            extractor.extract_all(cabinet, tmpdir,
+                                  progress: ->(*) { raise "progress boom" })
+          end
+        end.to raise_error(RuntimeError, "progress boom")
+
+        expect(extractor).to be_idle
       end
     end
   end
@@ -120,7 +155,7 @@ RSpec.describe "Cabriolet Memory Management" do
     describe "LZX" do
       let(:lzx_cab) { File.join(fixtures_dir, "lzx-premature-matches.cab") }
 
-      it "frees buffers when free is called" do
+      it "releases extractor state after extraction" do
         skip "LZX fixture not available" unless File.exist?(lzx_cab)
 
         decompressor = Cabriolet::CAB::Decompressor.new
@@ -135,21 +170,20 @@ RSpec.describe "Cabriolet Memory Management" do
           # Some test files may be intentionally malformed
         end
 
-        # After extraction, reset_state should have been called
-        # which calls free on the decompressor
-        expect(extractor.instance_variable_get(:@current_decomp)).to be_nil
+        # After extraction, reset_state should have released all extraction state
+        expect(extractor).to be_idle
       end
     end
 
-    describe "MSZIP" do
-      let(:mszip_cab) { File.join(fixtures_dir, "mszip_lzx_qtm.cab") }
+    describe "MSZIP/LZX/Quantum" do
+      let(:mixed_cab) { File.join(fixtures_dir, "mszip_lzx_qtm.cab") }
 
-      it "frees buffers when free is called" do
-        skip "MSZIP fixture not available" unless File.exist?(mszip_cab)
+      it "releases extractor state after extraction" do
+        skip "Mixed-format fixture not available" unless File.exist?(mixed_cab)
 
         decompressor = Cabriolet::CAB::Decompressor.new
         decompressor.salvage = true
-        cabinet = decompressor.search(mszip_cab) || decompressor.open(mszip_cab)
+        cabinet = decompressor.search(mixed_cab) || decompressor.open(mixed_cab)
         extractor = Cabriolet::CAB::Extractor.new(decompressor.io_system,
                                                   decompressor)
 
@@ -159,7 +193,7 @@ RSpec.describe "Cabriolet Memory Management" do
           # Some test files may be intentionally malformed
         end
 
-        expect(extractor.instance_variable_get(:@current_decomp)).to be_nil
+        expect(extractor).to be_idle
       end
     end
   end

--- a/spec/cab/memory_spec.rb
+++ b/spec/cab/memory_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Cabriolet Memory Management" do
         end
 
         expect(created).not_to be_nil
-        expect(created).to receive(:free)
+        expect(created).to receive(:free).and_call_original
 
         extractor.reset_state
       end


### PR DESCRIPTION
Five specs reached into `CAB::Extractor` to check cleanup.

- They read `@current_input`, `@current_decomp` and `@current_folder`.
- That was the last `instance_variable_get` in `spec/`.

Those specs guarded nothing:

- Delete `@current_decomp&.free` and all 1594 tests pass.
- Move `reset_state` off the `ensure` and they still pass.
- So the memory leak fix in 4572746 had no cover.

What replaces the ivar reads:

- `CAB::Extractor#idle?` reports whether extraction state is held.
- It also covers `@current_offset`, which the old assertions missed.

What now covers the leak fix:

- One example proves `reset_state` sends `free`.
- One proves state clears when `extract_all` raises.

Every claim is mutation-checked:

- Dropping any field's clearing turns an example red.
- Dropping either half of the leak fix does too.

One thing to know:

- `reset_state` and `idle?` list the same four fields.
- Nothing keeps them in step.
- Each carries a comment pointing at the other.
- `TODO.fixup/22` records the state-object fix.
