### PR TITLE
Extract shared command handler template into base class

### DIFF
--- a/lib/cabriolet/cab/command_handler.rb
+++ b/lib/cabriolet/cab/command_handler.rb
@@ -8,24 +8,6 @@ module Cabriolet
     # wrapping the existing CAB::Decompressor and CAB::Compressor classes.
     #
     class CommandHandler < Commands::BaseCommandHandler
-      # List CAB file contents
-      #
-      # Displays information about the cabinet including set ID, file count,
-      # and lists all contained files with their sizes.
-      #
-      # @param file [String] Path to the CAB file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def list(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        cabinet = decompressor.open(file)
-
-        display_header(cabinet)
-        display_files(cabinet.files)
-      end
-
       # Extract files from CAB archive
       #
       # Extracts all files from the cabinet to the specified output directory.
@@ -78,43 +60,27 @@ module Cabriolet
         puts "Created #{output} (#{bytes} bytes, #{files.size} files)"
       end
 
-      # Display detailed CAB file information
-      #
-      # Shows comprehensive information about the cabinet structure,
-      # including folders, files, and attributes.
-      #
-      # @param file [String] Path to the CAB file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def info(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        cabinet = decompressor.open(file)
-
-        display_cabinet_info(cabinet)
-      end
-
-      # Test CAB file integrity
-      #
-      # Verifies the integrity of the cabinet file structure.
-      # Note: Full integrity testing is not yet implemented.
-      #
-      # @param file [String] Path to the CAB file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def test(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        cabinet = decompressor.open(file)
-
-        puts "Testing #{cabinet.filename}..."
-        validate_integrity(file)
-        puts "OK: All #{cabinet.file_count} files passed integrity check"
-      end
-
       private
+
+      def decompressor_class
+        Decompressor
+      end
+
+      # Show the cabinet header followed by its files
+      def render_listing(session, _file, _options)
+        cabinet = session.archive
+        display_header(cabinet)
+        display_files(cabinet.files)
+      end
+
+      # Show comprehensive information about the cabinet structure
+      def render_info(session, _file)
+        display_cabinet_info(session.archive)
+      end
+
+      def render_test_result(session)
+        puts "OK: All #{session.archive.file_count} files passed integrity check"
+      end
 
       # Display cabinet header information
       #

--- a/lib/cabriolet/cab/decompressor.rb
+++ b/lib/cabriolet/cab/decompressor.rb
@@ -30,6 +30,18 @@ module Cabriolet
         @parser.parse(filename)
       end
 
+      # Close a cabinet (no-op for compatibility)
+      #
+      # Parser#parse opens and closes its own handle, so an opened cabinet holds
+      # no resources. This exists so every archive decompressor answers
+      # close(archive).
+      #
+      # @param _cabinet [Models::Cabinet] Cabinet to close
+      # @return [void]
+      def close(_cabinet = nil)
+        nil
+      end
+
       # Extract a single file from the cabinet
       #
       # @param file [Models::File] File to extract

--- a/lib/cabriolet/chm/command_handler.rb
+++ b/lib/cabriolet/chm/command_handler.rb
@@ -8,26 +8,6 @@ module Cabriolet
     # wrapping the existing CHM::Decompressor and CHM::Compressor classes.
     #
     class CommandHandler < Commands::BaseCommandHandler
-      # List CHM file contents
-      #
-      # Displays information about the CHM file including version,
-      # language, and lists all contained files with their sizes.
-      #
-      # @param file [String] Path to the CHM file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def list(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        chm = decompressor.open(file)
-
-        display_header(chm)
-        display_files(chm.all_files)
-
-        decompressor.close
-      end
-
       # Extract files from CHM archive
       #
       # Extracts all non-system files from the CHM file to the
@@ -94,46 +74,28 @@ module Cabriolet
         puts "Created #{output} (#{bytes} bytes, #{files.size} files)"
       end
 
-      # Display detailed CHM file information
-      #
-      # Shows comprehensive information about the CHM structure,
-      # including directory, sections, and files.
-      #
-      # @param file [String] Path to the CHM file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def info(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        chm = decompressor.open(file)
-
-        display_chm_info(chm)
-
-        decompressor.close
-      end
-
-      # Test CHM file integrity
-      #
-      # Verifies the CHM file structure.
-      #
-      # @param file [String] Path to the CHM file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def test(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        chm = decompressor.open(file)
-
-        puts "Testing #{chm.filename}..."
-        validate_integrity(file)
-        puts "OK: CHM file structure is valid (#{chm.all_files.size} files)"
-
-        decompressor.close
-      end
-
       private
+
+      def decompressor_class
+        Decompressor
+      end
+
+      # Show the CHM header followed by its files
+      def render_listing(session, _file, _options)
+        chm = session.archive
+        display_header(chm)
+        display_files(chm.all_files)
+      end
+
+      # Show comprehensive information about the CHM structure
+      def render_info(session, _file)
+        display_chm_info(session.archive)
+      end
+
+      def render_test_result(session)
+        count = session.archive.all_files.size
+        puts "OK: CHM file structure is valid (#{count} files)"
+      end
 
       # Display CHM header information
       #

--- a/lib/cabriolet/chm/decompressor.rb
+++ b/lib/cabriolet/chm/decompressor.rb
@@ -41,7 +41,13 @@ module Cabriolet
       end
 
       # Close the CHM file
-      def close
+      #
+      # The decompressor tracks the open handle itself, so the argument is
+      # accepted and ignored. It is optional so existing no-arg callers keep
+      # working.
+      #
+      # @param _chm [Models::CHMHeader, nil] Header to close
+      def close(_chm = nil)
         cleanup_lzx
         @input_handle&.close
         @input_handle = nil

--- a/lib/cabriolet/cli/base_command_handler.rb
+++ b/lib/cabriolet/cli/base_command_handler.rb
@@ -13,18 +13,47 @@ module Cabriolet
     # The base class provides common functionality and enforces a consistent
     # interface across all format handlers, following the Template Method pattern.
     #
+    # #list, #info and #test are implemented here as the shared
+    # validate -> open -> render -> close flow. A subclass supplies its
+    # decompressor and the three render hooks. #test inserts two more steps
+    # between open and render: it prints the "Testing <file>..." banner and
+    # runs validate_integrity, so a failed check aborts before the format's
+    # own report is written.
+    #
+    # A format whose read commands do not open an archive opts out by
+    # overriding #list, #info and #test outright. OAB does exactly that: it is
+    # a compressed stream rather than an archive, so it never reaches this
+    # template.
+    #
     # @example Creating a format handler
     #   module Cabriolet
     #     module CAB
-    #       class CommandHandler < CLI::BaseCommandHandler
-    #         def list(file, options = {})
-    #           # Implementation for listing CAB files
+    #       class CommandHandler < Commands::BaseCommandHandler
+    #         private
+    #
+    #         def decompressor_class
+    #           Decompressor
+    #         end
+    #
+    #         def render_listing(session, file, options)
+    #           # What #list prints
+    #         end
+    #
+    #         def render_info(session, file)
+    #           # What #info prints
+    #         end
+    #
+    #         def render_test_result(session)
+    #           # What #test prints once the integrity check passes
     #         end
     #       end
     #     end
     #   end
     #
     class BaseCommandHandler
+      # An opened archive together with the decompressor that opened it.
+      ArchiveSession = Struct.new(:decompressor, :archive)
+
       # Initialize the command handler
       #
       # @param verbose [Boolean] Enable verbose output
@@ -36,10 +65,12 @@ module Cabriolet
       #
       # @param file [String] Path to the archive file
       # @param options [Hash] Additional options
-      # @raise [NotImplementedError] Subclass must implement
+      # @return [void]
       def list(file, options = {})
-        raise NotImplementedError,
-              "#{self.class} must implement #list"
+        validate_file_exists(file)
+        session = open_archive(file)
+        render_listing(session, file, options)
+        close_archive(session)
       end
 
       # Extract files from archive
@@ -68,20 +99,28 @@ module Cabriolet
       #
       # @param file [String] Path to the archive file
       # @param options [Hash] Additional options
-      # @raise [NotImplementedError] Subclass must implement
-      def info(file, options = {})
-        raise NotImplementedError,
-              "#{self.class} must implement #info"
+      # @return [void]
+      def info(file, _options = {})
+        validate_file_exists(file)
+        session = open_archive(file)
+        render_info(session, file)
+        close_archive(session)
       end
 
       # Test archive integrity
       #
       # @param file [String] Path to the archive file
       # @param options [Hash] Additional options
-      # @raise [NotImplementedError] Subclass must implement
-      def test(file, options = {})
-        raise NotImplementedError,
-              "#{self.class} must implement #test"
+      # @return [void]
+      # @raise [Cabriolet::Error] if the integrity check fails
+      def test(file, _options = {})
+        validate_file_exists(file)
+        session = open_archive(file)
+
+        puts "Testing #{file}..."
+        validate_integrity(file)
+        render_test_result(session)
+        close_archive(session)
       end
 
       protected
@@ -138,6 +177,71 @@ module Cabriolet
         end
 
         report
+      end
+
+      private
+
+      # The decompressor class this format opens archives with
+      #
+      # @return [Class] A class answering #open(file) and #close(archive)
+      # @raise [NotImplementedError] Subclass must implement
+      def decompressor_class
+        raise NotImplementedError,
+              "#{self.class} must implement #decompressor_class"
+      end
+
+      # Open an archive and pair it with its decompressor
+      #
+      # @param file [String] Path to the archive file
+      # @return [ArchiveSession] The opened session
+      def open_archive(file)
+        decompressor = decompressor_class.new
+        ArchiveSession.new(decompressor, decompressor.open(file))
+      end
+
+      # Release an opened archive
+      #
+      # Deliberately not wrapped in an ensure. Anything that raises after the
+      # archive is opened skips this call and leaves it unclosed: a failing
+      # render, and in #test a failing validate_integrity too. That second path
+      # is not hypothetical — LIT takes it on every successfully opened file,
+      # because the Validator rejects the format outright. Preserving the
+      # existing semantics; adding cleanup is a separate concern.
+      #
+      # @param session [ArchiveSession] The session to close
+      # @return [void]
+      def close_archive(session)
+        session.decompressor.close(session.archive)
+      end
+
+      # Print the archive listing
+      #
+      # @param session [ArchiveSession] The opened session
+      # @param file [String] Path to the archive file
+      # @param options [Hash] Additional options
+      # @raise [NotImplementedError] Subclass must implement
+      def render_listing(session, file, options)
+        raise NotImplementedError,
+              "#{self.class} must implement #render_listing"
+      end
+
+      # Print detailed archive information
+      #
+      # @param session [ArchiveSession] The opened session
+      # @param file [String] Path to the archive file
+      # @raise [NotImplementedError] Subclass must implement
+      def render_info(session, file)
+        raise NotImplementedError,
+              "#{self.class} must implement #render_info"
+      end
+
+      # Print the outcome of a successful integrity check
+      #
+      # @param session [ArchiveSession] The opened session
+      # @raise [NotImplementedError] Subclass must implement
+      def render_test_result(session)
+        raise NotImplementedError,
+              "#{self.class} must implement #render_test_result"
       end
     end
   end

--- a/lib/cabriolet/hlp/command_handler.rb
+++ b/lib/cabriolet/hlp/command_handler.rb
@@ -9,26 +9,6 @@ module Cabriolet
     # Supports both QuickHelp and Windows Help formats.
     #
     class CommandHandler < Commands::BaseCommandHandler
-      # List HLP file contents
-      #
-      # Displays information about the HLP file including format type,
-      # and lists all contained files with their sizes.
-      #
-      # @param file [String] Path to the HLP file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def list(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
-
-        display_header(header, file)
-        display_files(decompressor, header)
-
-        decompressor.close(header)
-      end
-
       # Extract files from HLP archive
       #
       # Extracts all files from the HLP file to the specified output directory.
@@ -79,40 +59,26 @@ module Cabriolet
         end
       end
 
-      # Display detailed HLP file information
-      #
-      # Shows comprehensive information about the HLP structure,
-      # including format type, file count, and metadata.
-      #
-      # @param file [String] Path to the HLP file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def info(file, _options = {})
-        validate_file_exists(file)
+      private
 
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
-
-        display_hlp_info(header, file)
-
-        decompressor.close(header)
+      def decompressor_class
+        Decompressor
       end
 
-      # Test HLP file integrity
-      #
-      # Verifies the HLP file structure.
-      #
-      # @param file [String] Path to the HLP file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def test(file, _options = {})
-        validate_file_exists(file)
+      # Show the HLP header followed by its files
+      def render_listing(session, file, _options)
+        header = session.archive
+        display_header(header, file)
+        display_files(header)
+      end
 
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
+      # Show comprehensive information about the HLP structure
+      def render_info(session, file)
+        display_hlp_info(session.archive, file)
+      end
 
-        puts "Testing #{file}..."
-        validate_integrity(file)
+      def render_test_result(session)
+        header = session.archive
         format_name = begin
           version_value = header.version
           # Convert BinData objects to integer for comparison
@@ -127,11 +93,7 @@ module Cabriolet
           end
         end
         puts "OK: HLP file structure is valid (#{format_name} format)"
-
-        decompressor.close(header)
       end
-
-      private
 
       # Display HLP header information
       #
@@ -159,10 +121,9 @@ module Cabriolet
 
       # Display list of files in HLP
       #
-      # @param decompressor [Decompressor] The decompressor instance
       # @param header [Object] The HLP header object
       # @return [void]
-      def display_files(_decompressor, header)
+      def display_files(header)
         if header.files
           header.files.each do |f|
             puts "  #{f.filename} (#{f.length} bytes)"

--- a/lib/cabriolet/kwaj/command_handler.rb
+++ b/lib/cabriolet/kwaj/command_handler.rb
@@ -8,25 +8,6 @@ module Cabriolet
     # wrapping the existing KWAJ::Decompressor and KWAJ::Compressor classes.
     #
     class CommandHandler < Commands::BaseCommandHandler
-      # List KWAJ file information
-      #
-      # For KWAJ files, list displays detailed file information
-      # rather than a file listing (single file archive).
-      #
-      # @param file [String] Path to the KWAJ file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def list(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
-
-        display_kwaj_info(header, file)
-
-        decompressor.close(header)
-      end
-
       # Extract KWAJ compressed file
       #
       # Extracts/decompresses the KWAJ file to its original form.
@@ -114,46 +95,29 @@ module Cabriolet
         puts "Compressed #{file} to #{output} (#{bytes} bytes, #{compression} compression)"
       end
 
-      # Display detailed KWAJ file information
-      #
-      # @param file [String] Path to the KWAJ file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def info(file, _options = {})
-        validate_file_exists(file)
+      private
 
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
-
-        display_kwaj_info(header, file)
-
-        decompressor.close(header)
+      def decompressor_class
+        Decompressor
       end
 
-      # Test KWAJ file integrity
-      #
-      # Verifies the KWAJ file structure.
-      #
-      # @param file [String] Path to the KWAJ file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def test(file, _options = {})
-        validate_file_exists(file)
+      # KWAJ holds a single compressed file, so listing it is the same as
+      # describing it.
+      def render_listing(session, file, _options)
+        render_info(session, file)
+      end
 
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
+      def render_info(session, file)
+        display_kwaj_info(session.archive, file)
+      end
 
-        puts "Testing #{file}..."
-        validate_integrity(file)
+      def render_test_result(session)
+        header = session.archive
         puts "OK: KWAJ file structure is valid"
         puts "Compression: #{header.compression_name}"
         puts "Data offset: #{header.data_offset} bytes"
         puts "Uncompressed size: #{header.length || 'unknown'} bytes"
-
-        decompressor.close(header)
       end
-
-      private
 
       # Display KWAJ file information
       #

--- a/lib/cabriolet/lit/command_handler.rb
+++ b/lib/cabriolet/lit/command_handler.rb
@@ -90,12 +90,12 @@ module Cabriolet
 
       # DEAD CODE — unreachable through the command path, both branches.
       #
-      # #test calls validate_integrity before this hook, and the Validator reads
-      # 4 magic bytes and compares them against the 8-byte "ITOLITLS" signature
-      # (validator.rb:104, validator.rb:237), so every LIT file fails and this
-      # never runs. The encrypted? branch is doubly unreachable: LIT::Decompressor
-      # raises NotImplementedError for DRM files while opening them
-      # (lit/decompressor.rb:39). Preserved verbatim pending a Validator fix.
+      # #test calls validate_integrity before this hook, and
+      # Validator#validate_magic_bytes reads 4 magic bytes and compares them
+      # against the 8-byte "ITOLITLS" signature it expects for :lit, so every
+      # LIT file fails and this never runs. The encrypted? branch is doubly
+      # unreachable: LIT::Decompressor#open raises NotImplementedError for DRM
+      # files before returning. Preserved verbatim pending a Validator fix.
       def render_test_result(session)
         lit_file = session.archive
         if lit_file.encrypted?

--- a/lib/cabriolet/lit/command_handler.rb
+++ b/lib/cabriolet/lit/command_handler.rb
@@ -9,27 +9,6 @@ module Cabriolet
     # LIT files use LZX compression and may include DRM protection.
     #
     class CommandHandler < Commands::BaseCommandHandler
-      # List LIT file contents
-      #
-      # Displays information about the LIT file including version,
-      # language, and lists all contained files with their sizes.
-      #
-      # @param file [String] Path to the LIT file
-      # @param options [Hash] Additional options
-      # @option options [Boolean] :use_manifest Use manifest for original filenames
-      # @return [void]
-      def list(file, options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        lit_file = decompressor.open(file)
-
-        display_header(lit_file)
-        display_files(lit_file, decompressor, options)
-
-        decompressor.close(lit_file)
-      end
-
       # Extract files from LIT archive
       #
       # Extracts all files from the LIT file to the specified output directory.
@@ -92,52 +71,40 @@ module Cabriolet
         puts "Created #{output} (#{bytes} bytes, #{files.size} files)"
       end
 
-      # Display detailed LIT file information
-      #
-      # Shows comprehensive information about the LIT structure,
-      # including sections, manifest, and files.
-      #
-      # @param file [String] Path to the LIT file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def info(file, _options = {})
-        validate_file_exists(file)
+      private
 
-        decompressor = Decompressor.new
-        lit_file = decompressor.open(file)
-
-        display_lit_info(lit_file)
-
-        decompressor.close(lit_file)
+      def decompressor_class
+        Decompressor
       end
 
-      # Test LIT file integrity
-      #
-      # Verifies the LIT file structure.
-      #
-      # @param file [String] Path to the LIT file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def test(file, _options = {})
-        validate_file_exists(file)
+      # Show the LIT header followed by its files
+      def render_listing(session, _file, options)
+        display_header(session.archive)
+        display_files(session.archive, session.decompressor, options)
+      end
 
-        decompressor = Decompressor.new
-        lit_file = decompressor.open(file)
+      # Show comprehensive information about the LIT structure
+      def render_info(session, _file)
+        display_lit_info(session.archive)
+      end
 
-        puts "Testing #{file}..."
-        validate_integrity(file)
-        # Check for DRM
+      # DEAD CODE — unreachable through the command path, both branches.
+      #
+      # #test calls validate_integrity before this hook, and the Validator reads
+      # 4 magic bytes and compares them against the 8-byte "ITOLITLS" signature
+      # (validator.rb:104, validator.rb:237), so every LIT file fails and this
+      # never runs. The encrypted? branch is doubly unreachable: LIT::Decompressor
+      # raises NotImplementedError for DRM files while opening them
+      # (lit/decompressor.rb:39). Preserved verbatim pending a Validator fix.
+      def render_test_result(session)
+        lit_file = session.archive
         if lit_file.encrypted?
           puts "WARNING: LIT file is DRM-encrypted (level: #{lit_file.drm_level})"
           puts "Encryption is not supported by this implementation"
         else
           puts "OK: LIT file structure is valid (#{lit_file.directory.entries.size} files)"
         end
-
-        decompressor.close(lit_file)
       end
-
-      private
 
       # Display LIT header information
       #

--- a/lib/cabriolet/oab/command_handler.rb
+++ b/lib/cabriolet/oab/command_handler.rb
@@ -185,6 +185,21 @@ module Cabriolet
 
       private
 
+      # OAB opts out of the BaseCommandHandler template
+      #
+      # #list, #info and #test above override the template, so the inherited
+      # open/close flow never runs and this is never called. It exists so that
+      # removing one of those overrides fails with the real reason rather than
+      # the base class's "must implement #decompressor_class", which would be
+      # misleading advice here: OAB has no archive to open.
+      #
+      # @raise [NotImplementedError] always
+      def decompressor_class
+        raise NotImplementedError,
+              "#{self.class} does not open an archive; " \
+              "it overrides #list, #info and #test instead"
+      end
+
       # Display OAB file information
       #
       # @param file [String] Path to the OAB file

--- a/lib/cabriolet/szdd/command_handler.rb
+++ b/lib/cabriolet/szdd/command_handler.rb
@@ -8,25 +8,6 @@ module Cabriolet
     # wrapping the existing SZDD::Decompressor and SZDD::Compressor classes.
     #
     class CommandHandler < Commands::BaseCommandHandler
-      # List SZDD file information
-      #
-      # For SZDD files, list displays detailed file information
-      # rather than a file listing (single file archive).
-      #
-      # @param file [String] Path to the SZDD file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def list(file, _options = {})
-        validate_file_exists(file)
-
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
-
-        display_szdd_info(header, file)
-
-        decompressor.close(header)
-      end
-
       # Extract SZDD compressed file
       #
       # Expands the SZDD file to its original form.
@@ -101,45 +82,28 @@ module Cabriolet
         puts "Compressed #{file} to #{output} (#{bytes} bytes)"
       end
 
-      # Display detailed SZDD file information
-      #
-      # @param file [String] Path to the SZDD file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def info(file, _options = {})
-        validate_file_exists(file)
+      private
 
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
-
-        display_szdd_info(header, file)
-
-        decompressor.close(header)
+      def decompressor_class
+        Decompressor
       end
 
-      # Test SZDD file integrity
-      #
-      # Verifies the SZDD file structure.
-      #
-      # @param file [String] Path to the SZDD file
-      # @param options [Hash] Additional options (unused)
-      # @return [void]
-      def test(file, _options = {})
-        validate_file_exists(file)
+      # SZDD holds a single compressed file, so listing it is the same as
+      # describing it.
+      def render_listing(session, file, _options)
+        render_info(session, file)
+      end
 
-        decompressor = Decompressor.new
-        header = decompressor.open(file)
+      def render_info(session, file)
+        display_szdd_info(session.archive, file)
+      end
 
-        puts "Testing #{file}..."
-        validate_integrity(file)
+      def render_test_result(session)
+        header = session.archive
         puts "OK: SZDD file structure is valid"
         puts "Format: #{header.format.to_s.upcase}"
         puts "Uncompressed size: #{header.length} bytes"
-
-        decompressor.close(header)
       end
-
-      private
 
       # Display SZDD file information
       #

--- a/spec/cli/base_command_handler_spec.rb
+++ b/spec/cli/base_command_handler_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tempfile"
+require_relative "../support/fixtures"
+require_relative "../support/stdout_capture"
+
+# The abstract half of the Template Method: #list, #info and #test are
+# implemented in the base class and delegate to hooks a subclass must supply.
+# These specs pin what happens when it supplies none, because that error is the
+# only guidance a future format author gets.
+RSpec.describe Cabriolet::Commands::BaseCommandHandler do
+  include StdoutCapture
+
+  # Held in its own let so the example keeps a reference for its whole
+  # lifetime. Returning only the path lets the Tempfile be collected, and its
+  # finalizer unlinks the file underneath the assertions.
+  let(:tempfile) do
+    file = Tempfile.new(["bare", ".bin"])
+    file.write("payload")
+    file.close
+    file
+  end
+
+  let(:archive) { tempfile.path }
+
+  after { tempfile.close! }
+
+  describe "a subclass that implements nothing" do
+    subject(:handler) { bare_subclass.new(verbose: false) }
+
+    let(:bare_subclass) do
+      Class.new(described_class) do
+        def self.to_s
+          "BareCommandHandler"
+        end
+      end
+    end
+
+    it "reports the missing decompressor for #list" do
+      expect { handler.list(archive) }.to raise_error(
+        NotImplementedError,
+        "BareCommandHandler must implement #decompressor_class",
+      )
+    end
+
+    it "reports the missing decompressor for #info" do
+      expect { handler.info(archive) }.to raise_error(
+        NotImplementedError,
+        "BareCommandHandler must implement #decompressor_class",
+      )
+    end
+
+    it "reports the missing decompressor for #test" do
+      expect { handler.test(archive) }.to raise_error(
+        NotImplementedError,
+        "BareCommandHandler must implement #decompressor_class",
+      )
+    end
+
+    it "validates the file before reaching any hook" do
+      expect { handler.list("/nonexistent/file.bin") }.to raise_error(
+        ArgumentError, "File does not exist: /nonexistent/file.bin"
+      )
+    end
+  end
+
+  describe "a subclass that supplies only a decompressor" do
+    subject(:handler) { opened_subclass.new(verbose: false) }
+
+    # Getting past #open_archive makes the render hook the next thing to fail,
+    # which is the second error a format author meets.
+    let(:opened_subclass) do
+      Class.new(described_class) do
+        def self.to_s
+          "OpenedCommandHandler"
+        end
+
+        private
+
+        def decompressor_class
+          Class.new do
+            def open(file)
+              file
+            end
+
+            def close(archive)
+              archive
+            end
+          end
+        end
+      end
+    end
+
+    it "reports the missing listing renderer" do
+      expect { handler.list(archive) }.to raise_error(
+        NotImplementedError,
+        "OpenedCommandHandler must implement #render_listing",
+      )
+    end
+
+    it "reports the missing info renderer" do
+      expect { handler.info(archive) }.to raise_error(
+        NotImplementedError,
+        "OpenedCommandHandler must implement #render_info",
+      )
+    end
+
+    # #test prints the banner and runs validate_integrity before the render
+    # hook, so reaching that hook needs a file the Validator accepts. That the
+    # integrity step ran is not asserted here — this example would still pass
+    # if it were removed. The LIT characterization covers that.
+    it "reports the missing test renderer" do
+      cab = Fixtures.for(:cab).path(:basic)
+
+      expect do
+        capture_stdout { handler.test(cab) }
+      end.to raise_error(
+        NotImplementedError,
+        "OpenedCommandHandler must implement #render_test_result",
+      )
+    end
+  end
+
+  describe "a format that opts out of the template" do
+    # OAB overrides #list, #info and #test, so its #decompressor_class is
+    # unreachable in normal use. Widening the visibility in a subclass is how
+    # the message gets asserted without reaching in with #send. The message
+    # names whichever class is missing the hook, so here it names the subclass.
+    let(:exposed_oab) do
+      Class.new(Cabriolet::OAB::CommandHandler) do
+        def self.to_s
+          "OABSubclass"
+        end
+
+        public :decompressor_class
+      end
+    end
+
+    it "explains that the format does not open an archive" do
+      expect { exposed_oab.new(verbose: false).decompressor_class }
+        .to raise_error(
+          NotImplementedError,
+          "OABSubclass does not open an archive; " \
+          "it overrides #list, #info and #test instead",
+        )
+    end
+  end
+end

--- a/spec/cli/handler_output_spec.rb
+++ b/spec/cli/handler_output_spec.rb
@@ -1,0 +1,515 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../support/fixtures"
+require_relative "../support/stdout_capture"
+
+# Characterization specs for the format command handlers.
+#
+# For every handler's #list, #info and #test these pin the exact stdout, plus
+# the class and message of whatever the failing paths raise. The single
+# exception is CAB's #info, whose modification times render in the local zone
+# and are normalized before comparison.
+#
+# Return values are asserted in exactly one example: CAB's #list and #info,
+# which used to leak a file array and now return nil like every other handler.
+# Nothing else asserts a return value.
+#
+# The three methods share a validate -> open -> render -> close skeleton that
+# lives in BaseCommandHandler, so a change to the template must not change what
+# any format prints. The abstract hooks that skeleton calls are covered in
+# base_command_handler_spec.rb.
+RSpec.describe Cabriolet::Commands::BaseCommandHandler do
+  include StdoutCapture
+
+  # The three read-only commands the base class implements as a template.
+  def read_commands
+    %i[list info test]
+  end
+
+  def capture(handler, command, file, options = {})
+    capture_stdout { handler.public_send(command, file, options) }
+  end
+
+  def capture_failure(handler, command, file)
+    capture_stdout_failure { handler.public_send(command, file, {}) }
+  end
+
+  describe "CAB" do
+    let(:file) { Fixtures.for(:cab).path(:basic) }
+    let(:handler) { Cabriolet::CAB::CommandHandler.new(verbose: false) }
+
+    it "prints the cabinet listing" do
+      output, = capture(handler, :list, file)
+
+      expect(output).to eq(<<~OUT)
+        Cabinet: #{file}
+        Set ID: 1570, Index: 0
+        Folders: 1, Files: 2
+
+        Files:
+          hello.c (77 bytes)
+          welcome.c (74 bytes)
+      OUT
+    end
+
+    it "prints detailed cabinet information" do
+      output, = capture(handler, :info, file)
+      # Modification times render in the local zone; the rest is pinned exactly.
+      normalized = output.gsub(/^    Modified: .+$/, "    Modified: <TIME>")
+
+      expect(normalized).to eq(<<~OUT)
+        Cabinet Information
+        ==================================================
+        Filename: #{file}
+        Set ID: 1570
+        Set Index: 0
+        Size: 253 bytes
+        Folders: 1
+        Files: 2
+
+        Folders:
+          [0] None (1 blocks)
+
+        Files:
+          hello.c
+            Size: 77 bytes
+            Modified: <TIME>
+            Attributes: archive
+          welcome.c
+            Size: 74 bytes
+            Modified: <TIME>
+            Attributes: archive
+      OUT
+    end
+
+    it "prints the integrity report" do
+      output, = capture(handler, :test, file)
+
+      expect(output).to eq(<<~OUT)
+        Testing #{file}...
+        OK: All 2 files passed integrity check
+      OUT
+    end
+
+    # These used to leak the incidental value of a trailing files.each. Both
+    # are documented @return [void], and every other handler already returned
+    # nil, so the template normalizes them.
+    it "returns nil from #list and #info" do
+      _, listed = capture(handler, :list, file)
+      _, described = capture(handler, :info, file)
+
+      expect(listed).to be_nil
+      expect(described).to be_nil
+    end
+
+    it "raises ParseError before printing anything for a truncated cabinet" do
+      truncated = Fixtures.for(:cab).edge_case(:partial_shortheader)
+      output, error = capture_failure(handler, :test, truncated)
+
+      expect(output).to be_empty
+      expect(error).to be_a(Cabriolet::ParseError)
+      expect(error.message).to eq("Cannot read CAB header")
+    end
+  end
+
+  describe "CHM" do
+    let(:file) { Fixtures.for(:chm).path(:encints_64bit_both) }
+    let(:handler) { Cabriolet::CHM::CommandHandler.new(verbose: false) }
+
+    it "prints the CHM listing" do
+      output, = capture(handler, :list, file)
+
+      expect(output).to eq(<<~OUT)
+        CHM File: #{file}
+        Version: 2
+        Language: 1033
+        Chunks: 1, Chunk Size: 4096
+
+        Files:
+          good00 (127 bytes, Uncompressed)
+          good01 (128 bytes, Uncompressed)
+          good02 (16383 bytes, Uncompressed)
+          good03 (16384 bytes, Uncompressed)
+          good04 (2097151 bytes, Uncompressed)
+          good05 (2097152 bytes, Uncompressed)
+          good06 (268435455 bytes, Uncompressed)
+          good07 (268435456 bytes, Uncompressed)
+          good08 (2147483647 bytes, Uncompressed)
+          good09 (2147483648 bytes, Uncompressed)
+          good10 (34359738367 bytes, Uncompressed)
+          good11 (34359738368 bytes, Uncompressed)
+          good12 (4398046511103 bytes, Uncompressed)
+          good13 (4398046511104 bytes, Uncompressed)
+          good14 (562949953421311 bytes, Uncompressed)
+          good15 (562949953421312 bytes, Uncompressed)
+          good16 (72057594037927935 bytes, Uncompressed)
+          good17 (72057594037927936 bytes, Uncompressed)
+          good18 (9223372036854775807 bytes, Uncompressed)
+      OUT
+    end
+
+    def expected_chm_info(file)
+      <<~OUT
+        CHM File Information
+        ==================================================
+        Filename: #{file}
+        Version: 2
+        Language ID: 1033
+        Timestamp: 0
+        Size: 4292 bytes
+
+        Directory:
+          Offset: 196
+          Chunks: 1
+          Chunk Size: 4096
+          First PMGL: 0
+          Last PMGL: 0
+
+        Sections:
+          Section 0 (Uncompressed): offset 4292
+          Section 1 (MSCompressed): LZX compression
+
+        Files: 19 regular, 0 system
+
+        Regular Files:
+          good00
+            Size: 127 bytes (Sec0)
+          good01
+            Size: 128 bytes (Sec0)
+          good02
+            Size: 16383 bytes (Sec0)
+          good03
+            Size: 16384 bytes (Sec0)
+          good04
+            Size: 2097151 bytes (Sec0)
+          good05
+            Size: 2097152 bytes (Sec0)
+          good06
+            Size: 268435455 bytes (Sec0)
+          good07
+            Size: 268435456 bytes (Sec0)
+          good08
+            Size: 2147483647 bytes (Sec0)
+          good09
+            Size: 2147483648 bytes (Sec0)
+          good10
+            Size: 34359738367 bytes (Sec0)
+          good11
+            Size: 34359738368 bytes (Sec0)
+          good12
+            Size: 4398046511103 bytes (Sec0)
+          good13
+            Size: 4398046511104 bytes (Sec0)
+          good14
+            Size: 562949953421311 bytes (Sec0)
+          good15
+            Size: 562949953421312 bytes (Sec0)
+          good16
+            Size: 72057594037927935 bytes (Sec0)
+          good17
+            Size: 72057594037927936 bytes (Sec0)
+          good18
+            Size: 9223372036854775807 bytes (Sec0)
+      OUT
+    end
+
+    it "prints detailed CHM information" do
+      output, = capture(handler, :info, file)
+
+      expect(output).to eq(expected_chm_info(file))
+    end
+
+    it "prints the integrity report" do
+      output, = capture(handler, :test, file)
+
+      expect(output).to eq(<<~OUT)
+        Testing #{file}...
+        OK: CHM file structure is valid (19 files)
+      OUT
+    end
+  end
+
+  describe "HLP" do
+    let(:file) { Fixtures.for(:hlp).path(:masmlib) }
+    let(:handler) { Cabriolet::HLP::CommandHandler.new(verbose: false) }
+
+    it "prints the HLP listing" do
+      output, = capture(handler, :list, file)
+
+      expect(output).to eq(<<~OUT)
+        HLP File: #{file}
+        Format: WinHelp 4
+
+        Files:
+          (File listing not available for this format)
+      OUT
+    end
+
+    it "prints detailed HLP information" do
+      output, = capture(handler, :info, file)
+
+      expect(output).to eq(<<~OUT)
+        HLP File Information
+        ==================================================
+        Filename: #{file}
+        Format: WinHelp 4
+        Size: 108865 bytes
+      OUT
+    end
+
+    it "prints the integrity report" do
+      output, = capture(handler, :test, file)
+
+      expect(output).to eq(<<~OUT)
+        Testing #{file}...
+        OK: HLP file structure is valid (WinHelp 4 format)
+      OUT
+    end
+  end
+
+  describe "KWAJ" do
+    let(:file) { Fixtures.for(:kwaj).path(:f00) }
+    let(:handler) { Cabriolet::KWAJ::CommandHandler.new(verbose: false) }
+
+    it "prints the same report for #list and #info" do
+      listing, = capture(handler, :list, file)
+      described, = capture(handler, :info, file)
+
+      expect(listing).to eq(<<~OUT)
+        KWAJ File Information
+        ==================================================
+        Filename: #{file}
+        Compression: None
+        Data offset: 14 bytes
+        Uncompressed size: unknown bytes
+      OUT
+      expect(described).to eq(listing)
+    end
+
+    it "prints the integrity report" do
+      output, = capture(handler, :test, file)
+
+      expect(output).to eq(<<~OUT)
+        Testing #{file}...
+        OK: KWAJ file structure is valid
+        Compression: None
+        Data offset: 14 bytes
+        Uncompressed size: unknown bytes
+      OUT
+    end
+
+    it "raises ParseError before printing anything for a malformed header" do
+      malformed = Fixtures.for(:kwaj).edge_case(:f04)
+
+      read_commands.each do |command|
+        output, error = capture_failure(handler, command, malformed)
+
+        expect(output).to be_empty
+        expect(error).to be_a(Cabriolet::ParseError)
+        expect(error.message).to eq("File extension not null-terminated")
+      end
+    end
+  end
+
+  describe "LIT" do
+    let(:file) { Fixtures.for(:lit).path(:bill) }
+    let(:handler) { Cabriolet::LIT::CommandHandler.new(verbose: false) }
+
+    def expected_lit_listing
+      <<~OUT
+        LIT File: bill.lit
+        Version: 1
+        Language ID: 0x409
+        DRM Protected: No
+
+        Files:
+          /data/ (0 bytes)
+          /data/bill2/ (0 bytes)
+          /data/bill2/content (3286 bytes)
+          /data/~cov0001 (4855 bytes)
+          /data/~cov0002 (40423 bytes)
+          /data/~cov0003 (14214 bytes)
+          /data/~cov0004 (2245 bytes)
+          /data/~cov0005 (17929 bytes)
+          /data/~cov0006/ (0 bytes)
+          /data/~cov0006/content (422 bytes)
+          /DRMStorage/ (0 bytes)
+          /DRMStorage/DRMSealed (16 bytes)
+          /DRMStorage/DRMSource (24 bytes)
+          /DRMStorage/ValidationStream (8 bytes)
+          /manifest (276 bytes)
+          /meta (1232 bytes)
+          /pb1 (24 bytes)
+          /pb2 (20 bytes)
+          /pb3 (1 bytes)
+          ::DataSpace/NameList (120 bytes)
+          ::DataSpace/Storage/EbEncryptDS/Content (1968 bytes)
+          ::DataSpace/Storage/EbEncryptDS/ControlData (48 bytes)
+          ::DataSpace/Storage/EbEncryptDS/SpanInfo (16 bytes)
+          ::DataSpace/Storage/EbEncryptDS/Transform/List (32 bytes)
+          ::DataSpace/Storage/EbEncryptDS/Transform/{0A9007C6-4076-11D3-8789-0000F8105754}/InstanceData/ (0 bytes)
+          ::DataSpace/Storage/EbEncryptDS/Transform/{0A9007C6-4076-11D3-8789-0000F8105754}/InstanceData/ResetTable (48 bytes)
+          ::DataSpace/Storage/EbEncryptDS/Transform/{67F6E4A2-60BF-11D3-8540-00C04F58C3CF}/InstanceData/ (0 bytes)
+          ::DataSpace/Storage/EbEncryptOnlyDS/Content (8 bytes)
+          ::DataSpace/Storage/EbEncryptOnlyDS/ControlData (16 bytes)
+          ::DataSpace/Storage/EbEncryptOnlyDS/SpanInfo (8 bytes)
+          ::DataSpace/Storage/EbEncryptOnlyDS/Transform/List (16 bytes)
+          ::DataSpace/Storage/EbEncryptOnlyDS/Transform/{67F6E4A2-60BF-11D3-8540-00C04F58C3CF}/InstanceData/ (0 bytes)
+          ::DataSpace/Storage/MSCompressed/Content (0 bytes)
+          ::DataSpace/Storage/MSCompressed/ControlData (32 bytes)
+          ::DataSpace/Storage/MSCompressed/SpanInfo (8 bytes)
+          ::DataSpace/Storage/MSCompressed/Transform/List (16 bytes)
+          ::DataSpace/Storage/MSCompressed/Transform/{0A9007C6-4076-11D3-8789-0000F8105754}/InstanceData/ (0 bytes)
+          ::DataSpace/Storage/MSCompressed/Transform/{0A9007C6-4076-11D3-8789-0000F8105754}/InstanceData/ResetTable (0 bytes)
+          ::Transform/{0A9007C6-4076-11D3-8789-0000F8105754}/ (0 bytes)
+          ::Transform/{67F6E4A2-60BF-11D3-8540-00C04F58C3CF}/ (0 bytes)
+      OUT
+    end
+
+    it "prints the LIT header and file listing" do
+      output, = capture(handler, :list, file)
+
+      expect(output).to eq(expected_lit_listing)
+    end
+
+    it "prints detailed LIT information" do
+      output, = capture(handler, :info, file)
+
+      expect(output).to eq(<<~OUT)
+        LIT File Information
+        ==================================================
+        Filename: #{file}
+        Version: 1
+        Language ID: 0x409
+        Creator ID: 0
+
+        DRM Protection: None
+
+        Sections: 4
+          [0] MSCompressed
+              Transforms: {4C4C4F41-01CD-0000-0000-000000000000}
+          [1] EbEncryptOnlyDS
+              Transforms: {FFFFFFFF-FFFF-FFFF-0100-000000000000}
+
+        Files: 40
+
+        Manifest mappings: 0
+      OUT
+    end
+
+    # The Validator reads 4 magic bytes and compares them against the 8-byte
+    # "ITOLITLS" signature, so every LIT file fails the integrity check and
+    # #test never reaches its DRM report. Characterizing, not endorsing.
+    it "prints the banner then fails the integrity check" do
+      output, error = capture_failure(handler, :test, file)
+
+      expect(output).to eq(<<~OUT)
+        Testing #{file}...
+        ERROR: Invalid magic bytes for lit format
+      OUT
+      expect(error).to be_a(Cabriolet::Error)
+      expect(error.message).to eq("Integrity check failed")
+    end
+  end
+
+  describe "OAB" do
+    let(:file) { Fixtures.for(:oab).path(:simple) }
+    let(:handler) { Cabriolet::OAB::CommandHandler.new(verbose: false) }
+
+    it "prints the same report for #list and #info" do
+      listing, = capture(handler, :list, file)
+      described, = capture(handler, :info, file)
+
+      expect(listing).to eq(<<~OUT)
+        OAB File Information
+        ==================================================
+        Filename: #{file}
+        Type: Full OAB file
+        Version: 3.1
+        Target size: 35 bytes
+        Block max: 32768 bytes
+      OUT
+      expect(described).to eq(listing)
+    end
+
+    # OAB is the one format whose #test skips validate_integrity. The Validator
+    # has no magic bytes registered for :oab, so it rejects every OAB file; any
+    # format that ran it would abort the way LIT does. OAB reporting OK is
+    # therefore proof it never called it.
+    it "reports OK even though the validator rejects the file" do
+      report = Cabriolet::Validator.new(
+        file, level: Cabriolet::Validator::LEVEL_QUICK
+      ).validate
+      expect(report).not_to be_valid
+      expect(report.errors).to eq(["Invalid magic bytes for oab format"])
+
+      output, = capture(handler, :test, file)
+
+      expect(output).to eq(<<~OUT)
+        Testing #{file}...
+        OK: OAB full file structure is valid
+        Version: 3.1
+        Target size: 35 bytes
+        Block max: 32768 bytes
+      OUT
+    end
+  end
+
+  describe "SZDD" do
+    let(:file) { Fixtures.for(:szdd).path(:uninstall) }
+    let(:handler) { Cabriolet::SZDD::CommandHandler.new(verbose: false) }
+
+    it "prints the same report for #list and #info" do
+      listing, = capture(handler, :list, file)
+      described, = capture(handler, :info, file)
+
+      expect(listing).to eq(<<~OUT)
+        SZDD File Information
+        ==================================================
+        Filename: #{file}
+        Format: NORMAL
+        Uncompressed size: 40960 bytes
+        Missing character: 'e'
+        Suggested filename: UNINSTAL.EXE
+      OUT
+      expect(described).to eq(listing)
+    end
+
+    it "prints the integrity report" do
+      output, = capture(handler, :test, file)
+
+      expect(output).to eq(<<~OUT)
+        Testing #{file}...
+        OK: SZDD file structure is valid
+        Format: NORMAL
+        Uncompressed size: 40960 bytes
+      OUT
+    end
+  end
+
+  describe "a missing file" do
+    {
+      cab: Cabriolet::CAB::CommandHandler,
+      chm: Cabriolet::CHM::CommandHandler,
+      hlp: Cabriolet::HLP::CommandHandler,
+      kwaj: Cabriolet::KWAJ::CommandHandler,
+      lit: Cabriolet::LIT::CommandHandler,
+      oab: Cabriolet::OAB::CommandHandler,
+      szdd: Cabriolet::SZDD::CommandHandler,
+    }.each do |format, handler_class|
+      it "raises ArgumentError before printing anything for #{format}" do
+        handler = handler_class.new(verbose: false)
+        missing = "/nonexistent/file.#{format}"
+
+        read_commands.each do |command|
+          output, error = capture_failure(handler, command, missing)
+
+          expect(output).to be_empty
+          expect(error).to be_a(ArgumentError)
+          expect(error.message).to eq("File does not exist: #{missing}")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/stdout_capture.rb
+++ b/spec/support/stdout_capture.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+# Captures whatever a block writes to stdout
+#
+# The command handlers report by calling puts, so asserting on their output
+# means redirecting $stdout around the call. Restoring it has to happen in an
+# ensure, or one raising example silently swallows the rest of the suite's
+# output.
+module StdoutCapture
+  # Run a block with $stdout redirected
+  #
+  # @return [Array(String, Object)] What was printed, and the block's value
+  def capture_stdout
+    buffer = StringIO.new
+    original = $stdout
+    $stdout = buffer
+    value = yield
+    [buffer.string, value]
+  ensure
+    $stdout = original
+  end
+
+  # Run a block with $stdout redirected, trapping any error it raises
+  #
+  # Used to assert on output written before a failure, which the plain capture
+  # cannot reach because the exception propagates past it.
+  #
+  # @return [Array(String, StandardError, nil)] What was printed, and the error
+  def capture_stdout_failure
+    capture_stdout do
+      yield
+      nil
+    rescue StandardError => e
+      e
+    end
+  end
+end


### PR DESCRIPTION
Six handlers each rewrote the same skeleton.

- Validate the file, open a decompressor, render, close.
- The base class only raised `NotImplementedError`.

## Moves the shared flow into BaseCommandHandler

- Validate, open, render and close now live there once.
- `test` adds two steps: the banner, then `validate_integrity`.
- Subclasses supply a decompressor and three render hooks.
- CAB, CHM, HLP, KWAJ, LIT and SZDD use it.

`extract` and `create` stay put:

- CAB delegates to `extract_all`.
- CHM loops and filters system files.
- KWAJ and SZDD infer output names.
- OAB branches on incremental patches.
- No honest skeleton is shared by those.

## OAB opts out completely

- It is a compressed stream, not an archive.
- It never opens a decompressor for these commands.
- Its `list`, `info` and `test` are untouched.
- It gains one guard for a stray fallthrough.

## Normalizes three close protocols into one

- `CAB::Decompressor` had no `close` at all.
- `CHM::Decompressor#close` took no argument.
- Four others took one, three ignored it.
- Both gaps now accept an optional argument.
- No handler overrides close any more.
- Existing callers are unaffected.

## One behaviour change

- `CAB#list` and `CAB#info` now return `nil`.
- They returned an Array of files before.
- Both already documented `@return [void]`.
- The Array came from a trailing `files.each`.
- Nothing in the repo reads it.

## Nothing else moved

- Ran seven formats over every fixture and edge case.
- 252 cases, before and after the change.
- Diffed stdout, stderr and the raised exception.
- Every line matches except the return change.

New specs pin it:

- 36 characterization specs cover handler output.
- Eight cover the abstract hooks.
